### PR TITLE
Consensus policies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ http = "0.2"
 log = "0.4"
 trust-dns-resolver = "0.19"
 igd = {version="0.11", optional=true}
+rand = "0.7"
 
 [dev-dependencies]
 tokio-test = "0.2"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Additionally a single igd source can be instantiated if the feature is enabled
 (`discover_igd`), to retrieve the IP from an home router.
 If the feature is enabled `get_sources` will return it as a source too.
 
+
 # Runtime
 
 It requires to run with Tokio runtime due to the dependency on hyper if you use the HTTP resolver.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ This is the same as doing
   let value : Option<IpAddr>  = block_on(result);
 ```
 
+# Policies
+
+The library supports 3 consensus policies.
+
+- All
+  Query all sources in parallel and return the most common response
+- First
+  Query the sources one by one and return the first success
+- Random
+  Query the sources one by one in random order and return the first success
+
 # Changelog
 
 ## v2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,6 @@ use std::net::IpAddr;
 /// sources enabled.
 pub async fn get_ip() -> Option<IpAddr> {
     let sources: Sources = get_sources();
-    let consensus = ConsensusBuilder::new()
-        .add_sources(sources)
-        .build();
+    let consensus = ConsensusBuilder::new().add_sources(sources).build();
     consensus.get_consensus().await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ use std::net::IpAddr;
 /// sources enabled.
 pub async fn get_ip() -> Option<IpAddr> {
     let sources: Sources = get_sources();
-    let consensus = ConsensusBuilder::new().add_sources(sources).build();
+    let consensus = ConsensusBuilder::new()
+        .add_sources(sources)
+        .build();
     consensus.get_consensus().await
 }


### PR DESCRIPTION
Adds 3 policies to the consensus system to be able to cope with various a few more use cases.

- Random policy will most probably avoid getting on a ip service blacklist
- First policy is just for completeness but I have no idea who would like to use it
- All policy is the default to avoid changing behaviour without a major release