### PR TITLE
Remove tnx.nl/ip

### DIFF
--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -66,7 +66,6 @@ where
         "https://checkip.amazonaws.com/",
         "https://ident.me/",
         "http://whatismyip.akamai.com/",
-        "https://tnx.nl/ip",
         "https://myip.dnsomatic.com/",
         "https://diagnostic.opendns.com/myip",
     ]


### PR DESCRIPTION
A GET to https://tnx.nl/ip returns the following response (at least to me):

```
127.0.0.1
[33;1;5m--- after 12 years of service, tnx.nl/ip is no more. ---[0m
```
So it seems like they're no more, we should probably remove them from the list of builtin HTTP sources.