### PR TITLE
Handle rebrand of trust-dns-resolver to hickory-resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ Asynchronous library to retrieve the system external IP
 futures = "0.3"
 reqwest = {version = "0.12" }
 log = "0.4"
-trust-dns-resolver = {version="0.23", features=["tokio-runtime"]}
+hickory-resolver = "0.24"
 igd = { version = "0.12", optional = true }
 rand = "0.8"
 

--- a/src/sources/dns.rs
+++ b/src/sources/dns.rs
@@ -3,8 +3,8 @@ use log::trace;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 
-use trust_dns_resolver::config::*;
-use trust_dns_resolver::TokioAsyncResolver;
+use hickory_resolver::config::*;
+use hickory_resolver::TokioAsyncResolver;
 
 #[derive(Debug, Clone)]
 pub enum QueryType {
@@ -69,7 +69,7 @@ impl DNSSource {
                             config.add_name_server(NameServerConfig {
                                 bind_addr: None,
                                 socket_addr: address,
-                                protocol: trust_dns_resolver::config::Protocol::Udp,
+                                protocol: hickory_resolver::config::Protocol::Udp,
                                 tls_dns_name: Some(server.clone()),
                                 trust_negative_responses: true,
                             });

--- a/src/sources/interfaces.rs
+++ b/src/sources/interfaces.rs
@@ -25,7 +25,7 @@ pub enum Error {
     Http(reqwest::Error),
     DecodeError(std::str::Utf8Error),
     InvalidAddress(std::net::AddrParseError),
-    Dns(trust_dns_resolver::error::ResolveError),
+    Dns(hickory_resolver::error::ResolveError),
     DnsResolutionEmpty,
     UnsupportedFamily,
 
@@ -76,8 +76,8 @@ impl From<std::net::AddrParseError> for Error {
     }
 }
 
-impl From<trust_dns_resolver::error::ResolveError> for Error {
-    fn from(err: trust_dns_resolver::error::ResolveError) -> Error {
+impl From<hickory_resolver::error::ResolveError> for Error {
+    fn from(err: hickory_resolver::error::ResolveError) -> Error {
         Error::Dns(err)
     }
 }


### PR DESCRIPTION
 trust-dns-resolver was rebranded to hickory-resolver in October 2023 (see notice in https://crates.io/crates/trust-dns-resolver)