### PR TITLE
Remove HTTPSource https://diagnostic.opendns.com/myip

### DIFF
--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -60,7 +60,6 @@ where
         "https://ident.me/",
         "http://whatismyip.akamai.com/",
         "https://myip.dnsomatic.com/",
-        "https://diagnostic.opendns.com/myip",
         "https://api.ipify.org",
         "https://ifconfig.me/ip",
         "https://ipinfo.io/ip",


### PR DESCRIPTION
https://diagnostic.opendns.com/myip returns HTTP 404 error code, seems this service is no longer active.
Additionally, OpenDNS documentation no longer refers to this service.