### PR TITLE
Use thiserror crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4"
 hickory-resolver = "0.24"
 igd = { version = "0.12", optional = true }
 rand = "0.8"
+thiserror = "1.0.58"
 
 [dev-dependencies]
 tokio-test = "0.4"


### PR DESCRIPTION
Use of thiserror crate simplifies the code and eases future development while maintaining the same interface.
No backward compatibility is broken and no new dependency is actually added because hickory-resolver already depends on it.