### PR TITLE
HTTP source: add builder and identify IP version support

### DIFF
--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -1,6 +1,42 @@
 use crate::sources::interfaces::{Error, Family, IpFuture, IpResult, Source};
 use log::trace;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::time::Duration;
+
+pub struct HTTPSourceBuilder {
+    url: String,
+    timeout: Duration,
+    family: Family,
+}
+impl HTTPSourceBuilder {
+    pub fn new<S: Into<String>>(url: S) -> Self {
+        Self {
+            url: url.into(),
+            timeout: Duration::from_secs(30),
+            family: Family::Any,
+        }
+    }
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+    pub fn with_supported_family(mut self, family: Family) -> Self {
+        self.family = family;
+        self
+    }
+    pub fn build(self) -> HTTPSource {
+        let Self {
+            url,
+            timeout,
+            family,
+        } = self;
+        HTTPSource {
+            url,
+            timeout,
+            family,
+        }
+    }
+}
 
 /// HTTP(s) Source of the external ip
 ///
@@ -9,19 +45,22 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 #[derive(Debug, Clone)]
 pub struct HTTPSource {
     url: String,
-}
-
-impl HTTPSource {
-    fn source<S: Into<String>>(url: S) -> Box<dyn Source> {
-        Box::new(HTTPSource { url: url.into() })
-    }
+    timeout: Duration,
+    family: Family,
 }
 
 impl Source for HTTPSource {
     fn get_ip(&self, family: Family) -> IpFuture<'_> {
         async fn run(_self: &HTTPSource, family: Family) -> IpResult {
+            if !((_self.family == Family::Any)
+                || (family == Family::Any)
+                || (_self.family == family))
+            {
+                return Err(Error::UnsupportedFamily);
+            }
+
             trace!("Contacting {:?}", _self.url);
-            let client = reqwest::Client::builder().timeout(std::time::Duration::from_secs(30));
+            let client = reqwest::Client::builder().timeout(_self.timeout);
             let client = match family {
                 Family::IPv4 => client.local_address(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
                 Family::IPv6 => {
@@ -32,13 +71,12 @@ impl Source for HTTPSource {
             .build()?;
             let resp = client.get(&_self.url).send().await?.text().await?;
             let parsed_ip: IpAddr = resp.trim().parse()?;
-            if matches!(parsed_ip, IpAddr::V4(_)) && matches!(family, Family::IPv4 | Family::Any) {
-                return Ok(parsed_ip);
+            match (family, parsed_ip) {
+                (Family::Any, _)
+                | (Family::IPv4, IpAddr::V4(_))
+                | (Family::IPv6, IpAddr::V6(_)) => Ok(parsed_ip),
+                _ => Err(Error::UnsupportedFamily),
             }
-            if matches!(parsed_ip, IpAddr::V6(_)) && matches!(family, Family::IPv6 | Family::Any) {
-                return Ok(parsed_ip);
-            }
-            Err(Error::UnsupportedFamily)
         }
 
         Box::pin(run(self, family))
@@ -61,19 +99,25 @@ where
     T: std::iter::FromIterator<Box<dyn Source>>,
 {
     [
-        "https://icanhazip.com/",
-        "https://myexternalip.com/raw",
-        "https://ifconfig.io/ip",
-        "https://ipecho.net/plain",
-        "https://checkip.amazonaws.com/",
-        "https://ident.me/",
-        "http://whatismyip.akamai.com/",
-        "https://myip.dnsomatic.com/",
-        "https://api.ipify.org",
-        "https://ifconfig.me/ip",
-        "https://ipinfo.io/ip",
+        ("https://icanhazip.com/", Family::Any),
+        ("https://myexternalip.com/raw", Family::Any),
+        ("https://ifconfig.io/ip", Family::Any),
+        ("https://ipecho.net/plain", Family::Any),
+        ("https://checkip.amazonaws.com/", Family::IPv4),
+        ("https://ident.me/", Family::Any),
+        ("http://whatismyip.akamai.com/", Family::IPv4),
+        ("https://myip.dnsomatic.com/", Family::IPv4),
+        ("https://api.ipify.org", Family::IPv4),
+        ("https://ifconfig.me/ip", Family::Any),
+        ("https://ipinfo.io/ip", Family::IPv4),
     ]
     .iter()
-    .map(|x| HTTPSource::source(*x))
+    .cloned()
+    .map(|(url, family)| {
+        HTTPSourceBuilder::new(url)
+            .with_supported_family(family)
+            .build()
+    })
+    .map(|x| -> Box<dyn Source> { Box::new(x) })
     .collect()
 }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -7,7 +7,7 @@ mod igd;
 mod interfaces;
 
 pub use self::dns::{get_dns_sources, DNSSource, QueryType};
-pub use self::http::{get_http_sources, HTTPSource};
+pub use self::http::{get_http_sources, HTTPSource, HTTPSourceBuilder};
 #[cfg(feature = "igd")]
 pub use self::igd::IGD;
 pub use interfaces::*;


### PR DESCRIPTION
Add public HTTPSourceBuilder so we can safely add new features to HTTPSource without breaking backwards compatibility.

The user configurable options are:
 * Timeout: 30 seconds by default
 * Supported IP versions of the service: Family::Any by default